### PR TITLE
Updated batch_task field 8 format in schema.csv

### DIFF
--- a/schema.csv
+++ b/schema.csv
@@ -18,7 +18,7 @@ batch_task.csv,4, task id, INTEGER, YES
 batch_task.csv,5, number of instances, INTEGER, YES
 batch_task.csv,6, status, STRING, YES
 batch_task.csv,7, number of cpus requested per instance in the task, INTEGER, YES
-batch_task.csv,8, normalized memory requested per instance in the task, INTEGER, YES
+batch_task.csv,8, normalized memory requested per instance in the task, FLOAT, YES
 container_event.csv,1, timestamp, INTEGER, YES
 container_event.csv,2, event type, STRING, YES
 container_event.csv,3, instance id, INTEGER, YES


### PR DESCRIPTION
batch_task.csv field 8, normalized memory requested per instance in the task, is not an integer value.

For example, the first instance is 0.007956928014909534.

I've used FLOAT for consistency, although this isn't high enough precision in reality.