### PR TITLE
update datatype to string for server_event

### DIFF
--- a/cluster-trace-v2017/schema.csv
+++ b/cluster-trace-v2017/schema.csv
@@ -41,8 +41,8 @@ container_usage.csv,11, maximum cycles per instruction, FLOAT, NO
 container_usage.csv,12, maximum last-level cache misses per 1000 instructions, FLOAT, NO
 server_event.csv,1, timestamp, INTEGER, YES
 server_event.csv,2, machine id, INTEGER, YES
-server_event.csv,3, event type, INTEGER, YES
-server_event.csv,4, event detail, INTEGER, NO
+server_event.csv,3, event type, STRING, YES
+server_event.csv,4, event detail, STRING, NO
 server_event.csv,5, number of cpus, INTEGER, NO
 server_event.csv,6, normalized memory, FLOAT, NO
 server_event.csv,7, normalized disk space, FLOAT, NO


### PR DESCRIPTION
Hi,

I've noticed that in `schema.csv` there is `INTEGER` instead of `STRING` for the fields `event_type` and `event_detail`.
Here is a screenshot showing that the values are text:
![string-val-server-event](https://user-images.githubusercontent.com/29780475/123110689-9c47a780-d43c-11eb-84bb-94651320746b.png)

Best regards,
Felix

